### PR TITLE
Alternate recipe for Bloody Dark Stone Brick

### DIFF
--- a/overrides/kubejs/data/lychee/recipes/blood_stone_alternate.json
+++ b/overrides/kubejs/data/lychee/recipes/blood_stone_alternate.json
@@ -1,0 +1,44 @@
+{
+    "type": "lychee:block_interacting",
+    "item_in": {
+        "type": "forge:nbt",
+        "item": "vampirism:blood_bottle",
+        "nbt": "{Damage:9}"
+    },
+    "block_in": {
+    "blocks": ["minecraft:deepslate_bricks"]
+    },
+    "post": [
+        {
+            "type": "drop_item",
+            "item": "vampirism:blood_bottle",
+            "contextual": {
+                "type": "chance",
+                "chance": 1.0
+            }
+        },
+        {
+            "type": "place",
+            "contextual": [
+              {
+                "type": "chance",
+                "chance": 100
+              }
+            ],
+            "block": {
+              "blocks": [
+                "vampirism:bloody_dark_stone_bricks"
+              ]
+            }
+          },
+
+{
+"type": "execute",
+"command": "execute at @p run playsound vampirism:block.boiling master @p ~ ~ ~ 1.0 1.0",
+"hide": true
+
+}
+
+
+    ]
+}


### PR DESCRIPTION
_Draft PR as I don't know if anything else is needed for this.  Please let me know if so and I'll add it._

Adds an alternate recipe for blood stones using filled blood bottles instead of vampire blood bottles.

As a vampire, it is difficult to acquire Vampire Blood, so an alternate recipe using filled blood bottles seems fair.