### PR TITLE
Change chemical infusion cost of Infused alloy 

### DIFF
--- a/overrides/kubejs/data/mekanism/recipes/metallurgic_infusing/alloy/infused.json
+++ b/overrides/kubejs/data/mekanism/recipes/metallurgic_infusing/alloy/infused.json
@@ -1,1 +1,1 @@
-{"type":"mekanism:metallurgic_infusing","chemicalInput":{"amount":90,"tag":"mekanism:redstone"},"itemInput":{"ingredient":{"item":"create:brass_ingot"}},"output":{"item":"mekanism:alloy_infused"}}
+{"type":"mekanism:metallurgic_infusing","chemicalInput":{"amount":80,"tag":"mekanism:redstone"},"itemInput":{"ingredient":{"item":"create:brass_ingot"}},"output":{"item":"mekanism:alloy_infused"}}


### PR DESCRIPTION
Changes the chemical cost of 90 redstone to 80 redstone for the Infused alloy Recipe. Im 95% sure this was a typo, as the other two are 80, and most other infusion crafting recipes require some multiple of 80, because each enriched product gives 80. 