### PR TITLE
more modded ores for puffish_skills mining experience list

### DIFF
--- a/overrides/kubejs/data/puffish_skills/puffish_skills/categories/mining/experience.json
+++ b/overrides/kubejs/data/puffish_skills/puffish_skills/categories/mining/experience.json
@@ -323,6 +323,19 @@
 							}
 						]
 					},
+					"cobalt_ore": {
+						"operations": [
+							{
+								"type": "get_mined_block_state"
+							},
+							{
+								"type": "puffish_skills:test",
+								"data": {
+									"block": "tconstruct:cobalt_ore"
+								}
+							}
+						]
+					},
 					"deepslate_coal_ore": {
 						"operations": [
 							{
@@ -585,7 +598,7 @@
 				"experience": [
 			
 					{
-						"condition": "!silk_touch & (coal_ore | copper_ore | iron_ore | gold_ore | redstone_ore | lapis_ore | diamond_ore | emerald_ore | cinnabar_ore | lead_ore | nickel_ore | niter_ore | silver_ore | sulfur_ore | tin_ore | zinc_ore | bismuthinite_ore | iridium_lean_ore | fluorite_ore | osmium_ore | uranium_ore)",
+						"condition": "!silk_touch & (coal_ore | copper_ore | iron_ore | gold_ore | redstone_ore | lapis_ore | diamond_ore | emerald_ore | cinnabar_ore | lead_ore | nickel_ore | niter_ore | silver_ore | sulfur_ore | tin_ore | zinc_ore | bismuthinite_ore | iridium_lean_ore | fluorite_ore | osmium_ore | uranium_ore | cobalt_ore)",
 						"expression": "1"
 					},
 					{

--- a/overrides/kubejs/data/puffish_skills/puffish_skills/categories/mining/experience.json
+++ b/overrides/kubejs/data/puffish_skills/puffish_skills/categories/mining/experience.json
@@ -258,6 +258,71 @@
 							}
 						]
 					},
+					"bismuthinite_ore": {
+						"operations": [
+							{
+								"type": "get_mined_block_state"
+							},
+							{
+								"type": "puffish_skills:test",
+								"data": {
+									"block": "tinkers_advanced:bismuthinite_ore"
+								}
+							}
+						]
+					},
+					"iridium_lean_ore": {
+						"operations": [
+							{
+								"type": "get_mined_block_state"
+							},
+							{
+								"type": "puffish_skills:test",
+								"data": {
+									"block": "tinkers_advanced:iridium_lean_ore"
+								}
+							}
+						]
+					},
+					"fluorite_ore": {
+						"operations": [
+							{
+								"type": "get_mined_block_state"
+							},
+							{
+								"type": "puffish_skills:test",
+								"data": {
+									"block": "mekanism:fluorite_ore"
+								}
+							}
+						]
+					},
+					"osmium_ore": {
+						"operations": [
+							{
+								"type": "get_mined_block_state"
+							},
+							{
+								"type": "puffish_skills:test",
+								"data": {
+									"block": "mekanism:osmium_ore"
+								}
+							}
+						]
+					},
+					"uranium_ore": {
+						"operations": [
+							{
+								"type": "get_mined_block_state"
+							},
+							{
+								"type": "puffish_skills:test",
+								"data": {
+									"block": "mekanism:uranium_ore"
+								}
+							}
+						]
+					},
 					"deepslate_coal_ore": {
 						"operations": [
 							{
@@ -463,16 +528,68 @@
 								}
 							}
 						]
+					},
+					"bismuthinite_ore_deepslate": {
+						"operations": [
+							{
+								"type": "get_mined_block_state"
+							},
+							{
+								"type": "puffish_skills:test",
+								"data": {
+									"block": "tinkers_advanced:bismuthinite_ore_deepslate"
+								}
+							}
+						]
+					},
+					"deepslate_fluorite_ore": {
+						"operations": [
+							{
+								"type": "get_mined_block_state"
+							},
+							{
+								"type": "puffish_skills:test",
+								"data": {
+									"block": "mekanism:deepslate_fluorite_ore"
+								}
+							}
+						]
+					},
+					"deepslate_osmium_ore": {
+						"operations": [
+							{
+								"type": "get_mined_block_state"
+							},
+							{
+								"type": "puffish_skills:test",
+								"data": {
+									"block": "mekanism:deepslate_osmium_ore"
+								}
+							}
+						]
+					},
+					"deepslate_uranium_ore": {
+						"operations": [
+							{
+								"type": "get_mined_block_state"
+							},
+							{
+								"type": "puffish_skills:test",
+								"data": {
+									"block": "mekanism:deepslate_uranium_ore"
+								}
+							}
+						]
 					}
 				},
 				"experience": [
 			
 					{
-						"condition": "!silk_touch & (coal_ore | copper_ore | iron_ore | gold_ore | redstone_ore | lapis_ore | diamond_ore | emerald_ore | cinnabar_ore | lead_ore | nickel_ore | niter_ore | silver_ore | sulfur_ore | tin_ore | zinc_ore)",
+						"condition": "!silk_touch & (coal_ore | copper_ore | iron_ore | gold_ore | redstone_ore | lapis_ore | diamond_ore | emerald_ore | cinnabar_ore | lead_ore | nickel_ore | niter_ore | silver_ore | sulfur_ore | tin_ore | zinc_ore | bismuthinite_ore | iridium_lean_ore | fluorite_ore | osmium_ore | uranium_ore)",
 						"expression": "1"
 					},
 					{
-						"condition": "!silk_touch & (deepslate_coal_ore | deepslate_copper_ore | deepslate_iron_ore | deepslate_gold_ore | deepslate_redstone_ore | deepslate_lapis_ore | deepslate_diamond_ore | deepslate_emerald_ore | deepslate_cinnabar_ore | deepslate_lead_ore | deepslate_nickel_ore | deepslate_niter_ore | deepslate_silver_ore | deepslate_sulfur_ore | deepslate_tin_ore | deepslate_zinc_ore)",
+						"condition": "!silk_touch & (deepslate_coal_ore | deepslate_copper_ore | deepslate_iron_ore | deepslate_gold_ore | deepslate_redstone_ore | deepslate_lapis_ore | deepslate_diamond_ore | deepslate_emerald_ore | deepslate_cinnabar_ore | deepslate_lead_ore | deepslate_nickel_ore | deepslate_niter_ore | deepslate_silver_ore | deepslate_sulfur_ore | deepslate_tin_ore | deepslate_zinc_ore | bismuthinite_ore_deepslate | deepslate_fluorite_ore | deepslate_osmium_ore | deepslate_uranium_ore)",
 						"expression": "5"
 					}
 				]


### PR DESCRIPTION
continuation of #257 

Should be most ores now. I think still missing is vanilla ancient debris. Also probably some minor/special modded things, that are rare (like arcance debris).
Also not sure if nether gold ore or similar stuff is covered by the default vanilla ore setting. Also maybe some end ore missing.

Will possibly add those missing things in the future.

---

Other thoughts not covered in this PR:
The mining skill tree itself could probably be much more interesting.
If there's bigger overhaul for that at some point in the future it would probably also make sense to rebalance the XP thingy a bit, for example some non-ores could also give some XP (clay, amethyst etc.). To balance that out the whole XP progression would need to be checked. And all that with the context of the overhauled skill tree.
But as I mentioned those are just thoughts, my PRs so far were only in regards to bringing modded ores in line with vanilla ores, nothing more.