### PR TITLE
Added ability to craft a vanilla chest from any planks

### DIFF
--- a/overrides/kubejs/server_scripts/Common/Recipes/tag_alt_recipes.js
+++ b/overrides/kubejs/server_scripts/Common/Recipes/tag_alt_recipes.js
@@ -13,4 +13,13 @@ ServerEvents.recipes(event => {
   {
     P: 'minecraft:stick'
   })
+  //Craft chests from ANY planks
+  event.shaped(Item.of('minecraft:chest', 1), [
+        'PPP',
+        'P P',
+        'PPP'
+  ],
+  {
+        P: '#minecraft:planks'
+  })
 })


### PR DESCRIPTION
right now you can only make chests with vanilla planks, now you can make them with any planks.

This will create a conflict with crafting tables that don't support recipe swapping, like Tinker's Crafting Station - however I feel this is a much better solution that many have been asking for (see https://github.com/adam9899/MC-Eternal-2/issues/228)


(reopened pull request since I messed up my repo, this one is fixed @anabsolutesloth)