### PR TITLE
Fix AE2 "Fluix ME Smart Cable" Recipe

### DIFF
--- a/overrides/kubejs/server_scripts/Common/Recipes/ae2.js
+++ b/overrides/kubejs/server_scripts/Common/Recipes/ae2.js
@@ -9,4 +9,13 @@ ServerEvents.recipes(event => {
         C: "mekanism:elite_control_circuit",
         E: "minecraft:echo_shard"
     }).id("ae2wtlib:quantum_bridge_card")
+
+    event.remove({id: 'ae2:network/cables/smart_fluix'}) //Remove old recipe
+
+    event.shapeless(Item.of('ae2:fluix_smart_cable', 4), [
+    '4x ae2:fluix_covered_cable',
+    'minecraft:redstone',
+    'minecraft:glowstone_dust',
+  ]
+)
 })


### PR DESCRIPTION
The current Flux Me Dense Smart Cable has 2 recipes;
1) Fluix ME Dense Covered Cable + Redstone + Glowstone Dust => Fluix ME Dense Smart Cable
2) 4x Fluix ME Smart Cable => Fluix ME Dense Smart Cable

The 2nd recipe is 4x as expensive Redstone & Glowstone Dust wise due to the following recipe;
Fluix Me Covered Cable + Redstone + Glowstone Dust => Fluix ME Smart Cable

This Fix changes the recipe to require '4x Fluix Me Covered Cables' and output '4x Fluix ME Smart Cable' in order to standardise the recipes costs;
4x Fluix Me Covered Cable + Redstone + Glowstone Dust => 4x Fluix ME Smart Cable