### PR TITLE
make mega veins generate only Thermal ores (for unification)

### DIFF
--- a/overrides/config/adlods/Deposits/lead.cfg
+++ b/overrides/config/adlods/Deposits/lead.cfg
@@ -29,7 +29,8 @@ Deposit {
     # means that gold and iron will be in the proportion 1 to 5.
     # 
     S:ores <
-        #forge:ores/lead
+        thermal:lead_ore
+        thermal:deepslate_lead_ore
      >
 
     # Rarity (in chunks) of this deposit.

--- a/overrides/config/adlods/Deposits/silver.cfg
+++ b/overrides/config/adlods/Deposits/silver.cfg
@@ -29,7 +29,8 @@ Deposit {
     # means that gold and iron will be in the proportion 1 to 5.
     # 
     S:ores <
-        #forge:ores/silver
+        thermal:silver_ore
+        thermal:deepslate_silver_ore
      >
 
     # Rarity (in chunks) of this deposit.

--- a/overrides/config/adlods/Deposits/tin.cfg
+++ b/overrides/config/adlods/Deposits/tin.cfg
@@ -29,7 +29,8 @@ Deposit {
     # means that gold and iron will be in the proportion 1 to 5.
     # 
     S:ores <
-        #forge:ores/tin
+        thermal:tin_ore
+        thermal:deepslate_tin_ore
      >
 
     # Rarity (in chunks) of this deposit.


### PR DESCRIPTION
This fixes (some) mega veins being possible to generate in the "wrong" (non-unified) mod ore (e.g. Occultism silver instead of Thermal silver). Considering all natural spawns are Thermal ores I think, the mega veins should generate the same mod ore.

I mentioned the issue first here: https://github.com/adam9899/MC-Eternal-2/pull/431#issuecomment-3105305857