### PR TITLE
fixed typo in Tinker's Construct quests

### DIFF
--- a/overrides/config/ftbquests/quests/chapters/6modular_tools.snbt
+++ b/overrides/config/ftbquests/quests/chapters/6modular_tools.snbt
@@ -1637,7 +1637,7 @@
 				id: "5D7B2500C94EEBE0"
 				type: "advancement"
 			}]
-			title: "&eTravel Preperation!"
+			title: "&eTravel Preparation!"
 			x: 8.273809523809518d
 			y: 1.9999999999999858d
 		}


### PR DESCRIPTION
Fixed "preperation" to "preparation"