### PR TITLE
fix puffish skills not working correctly

### DIFF
--- a/overrides/kubejs/data/puffish_skills/puffish_skills/categories/combat/definitions.json
+++ b/overrides/kubejs/data/puffish_skills/puffish_skills/categories/combat/definitions.json
@@ -69,7 +69,7 @@
 				"data": {
 					"attribute": "puffish_attributes:player.melee_damage",
 					"value": 0.12,
-					"operation": "addition"
+					"operation": "multiply_total"
 				}
 			}
 		]
@@ -94,7 +94,7 @@
 				"data": {
 					"attribute": "puffish_attributes:player.ranged_damage",
 					"value": 0.07,
-					"operation": "addition"
+					"operation": "multiply_total"
 				}
 			}
 		]
@@ -151,7 +151,7 @@
 				"data": {
 					"attribute": "puffish_attributes:player.melee_damage",
 					"value": 0.03,
-					"operation": "addition"
+					"operation": "multiply_total"
 				}
 			}
 		]
@@ -170,7 +170,7 @@
 				"data": {
 					"attribute": "puffish_attributes:player.ranged_damage",
 					"value": 0.03,
-					"operation": "addition"
+					"operation": "multiply_total"
 				}
 			}
 		]

--- a/overrides/kubejs/data/puffish_skills/puffish_skills/categories/mining/definitions.json
+++ b/overrides/kubejs/data/puffish_skills/puffish_skills/categories/mining/definitions.json
@@ -32,7 +32,7 @@
 				"data": {
 					"attribute": "puffish_attributes:player.mining_speed",
 					"value": 0.03,
-					"operation": "addition"
+					"operation": "multiply_base"
 				}
 			}
 		]


### PR DESCRIPTION
Emper did goofed when fixing some things previously.
That also explains why people complained about mining slower and doing less damage in 1.1.1 which I read multiple times on the Discord.
Thus also resolves #471.

I also did some experiments and have some comparisons numbers as screenshot, if you wanna have them.
But the short version should be obvious in the code: If I have a 20 dmg weapon Empers previous changed made it so I get like .2 bonus damage as absolute values (20 -> 20.2) while now it does actual the 20% more damage it should do (20 -> 24).
Same with mining speed: Instead of .25 mining speed as absolute I know get 25% actually mining speed bonus.
(those example % are from my current game, of course those depend on the number of unlocked skills).