### PR TITLE
add foodbook to tome

### DIFF
--- a/overrides/config/ftbquests/quests/chapters/introduction.snbt
+++ b/overrides/config/ftbquests/quests/chapters/introduction.snbt
@@ -3968,6 +3968,12 @@
 									}
 								}
 							}
+							solcarrot: {
+								0: {
+									Count: 1b
+									id: "solcarrot:food_book"
+								}
+							}
 						}
 						"eccentrictome:version": 1
 					}
@@ -7976,3 +7982,4 @@
 	]
 	title: "&6A New Start! &a(Recommended!)"
 }
+


### PR DESCRIPTION
Seems like lots of players don't know about this basic but useful book. Hopefully adding this to the tome will increase its visibility and thus also lead to better prepared players and bring the max health that we can expect from players more in line.

(In general I think the eccentric tome should mostly contain "weird", small, basic books, while starter quests of mod chapters should reward their own book. This would keep the eccentric tome more focused and less overwhelming and players would get the exact book they need at the right moment when they start doing specific mods via the chapters.)