### PR TITLE
enable player arrow on minimap per default

### DIFF
--- a/overrides/config/xaerominimap.txt
+++ b/overrides/config/xaerominimap.txt
@@ -41,8 +41,8 @@ waypointsDistanceExp:0
 waypointsDistanceMin:0.0
 defaultWaypointTPCommandFormat:/tp @s {x} {y} {z}
 defaultWaypointTPCommandRotationFormat:/tp @s {x} {y} {z} {yaw} ~
-arrowScale:1.0000000149011612
-arrowColour:4
+arrowScale:1.7
+arrowColour:0
 smoothDots:false
 worldMap:true
 terrainDepth:true
@@ -68,7 +68,7 @@ compassDirectionScale:0
 caveMapsDepth:30
 hideWaypointCoordinates:false
 renderAllSets:false
-playerArrowOpacity:1
+playerArrowOpacity:75
 waypointsBottom:false
 minimapShape:0
 lightOverlayType:0


### PR DESCRIPTION
It just makes sense to have this.
This should reduce the number of questions asked on the Discord how to enable the arrow.

It should produce a red arrow in a good, sensible size. Red is a good color because it contrasts well with the usual background color (green) but also with stoney grey, snowy white etc. Even in the nether this shade of red seems to work quite well.