### PR TITLE
Vampirism - Enable vampire forests

### DIFF
--- a/overrides/config/vampirism-common.toml
+++ b/overrides/config/vampirism-common.toml
@@ -23,7 +23,7 @@
 	#Settings here require a game restart
 	[common-server.world]
 		#Whether to inject the vampire forest into the default overworld generation and to replace some Taiga areas
-		addVampireForestToOverworld = false
+		addVampireForestToOverworld = true
 		#Only considered if terrablender installed. Heigher values increase Vampirism region weight (likelyhood to appear)
 		#Range: 1 ~ 1000
 		vampireForestWeight_terrablender = 1


### PR DESCRIPTION
https://wiki.vampirism.dev/docs/wiki/content/biomes

If it wasn't disabled for a specific reason, I would enable it because it enriches gameplay for players who like Vampirism.