### PR TITLE
[Bug Fix] Disable Spawn Chunks to Fix Mob Cap

### DIFF
--- a/overrides/config/servercore/config.yml
+++ b/overrides/config/servercore/config.yml
@@ -4,7 +4,7 @@
 # Most miscellaneous feature toggles.
 features:
   # Stops the server from loading spawn chunks.
-  disable-spawn-chunks: false
+  disable-spawn-chunks: true
   # Prevents lagspikes caused by players moving into unloaded chunks.
   prevent-moving-into-unloaded-chunks: false
   # The amount of ticks between auto-saves when /save-on is active.


### PR DESCRIPTION
The spawn chunks were causing issues on my server where they would increase the mob total due to entities being loaded there. This prevented any new mobs from spawning. 