### PR TITLE
fix(#572): Ocean Piercer missing enchants info

### DIFF
--- a/overrides/config/ftbquests/quests/chapters/fishing.snbt
+++ b/overrides/config/ftbquests/quests/chapters/fishing.snbt
@@ -2082,7 +2082,6 @@
 									lvl: 3
 								}
 							]
-							HideFlags: 1
 							Unbreakable: 1b
 							display: {
 								Lore: ["{\"text\":\"§6Legendary\"}"]


### PR DESCRIPTION
This fixes #572

<img width="479" height="401" alt="image" src="https://github.com/user-attachments/assets/ece828b5-ccca-47bb-a295-7d995216bbe9" />