### PR TITLE
fix(#93): Lexica Botania Progression Bugged

### DIFF
--- a/overrides/config/ftbquests/quests/chapters/botania.snbt
+++ b/overrides/config/ftbquests/quests/chapters/botania.snbt
@@ -260,13 +260,25 @@
 		{
 			description: ["{mce.questing.botania.lexica_botania.desc}"]
 			id: "6D4AF11629E04986"
-			rewards: [{
-				amount: 50L
-				currency: "eternalcurrencies:coins"
-				id: "77CB4CB067A362F6"
-				ignore_reward_blocking: true
-				type: "eternalcurrencies:currency"
-			}]
+			rewards: [
+				{
+					amount: 50L
+					currency: "eternalcurrencies:coins"
+					id: "77CB4CB067A362F6"
+					ignore_reward_blocking: true
+					type: "eternalcurrencies:currency"
+				}
+				{
+					auto: "enabled"
+					command: "/advancement grant @p only botania:main/flower_pickup_lexicon"
+					console: true
+					icon: "botania:lexicon"
+					id: "5A3F2D1B8C4E9F7A"
+					silent: true
+					title: "Initialize Lexica Botania"
+					type: "command"
+				}
+			]
 			subtitle: "{mce.questing.botania.lexica_botania.sub}"
 			tasks: [{
 				id: "2C1EBB89070F54F9"


### PR DESCRIPTION
This fixes #93

From what I gather, mystical flowers were disabled here:

https://github.com/adam9899/MC-Eternal-2/blob/67c6dfbfd70eb268c65e6b5f83939073bbb861f0/overrides/kubejs/startup_scripts/nobotaniaflowers.js#L1-L4

But were added as indicators for ores (?):

https://github.com/adam9899/MC-Eternal-2/blob/67c6dfbfd70eb268c65e6b5f83939073bbb861f0/overrides/config/adlods/Deposits/iron.cfg#L139-L147

But I suspect this is rare or very rare. This PR introduces an extra automatic reward for the first quest, which silently triggers the `flower_pickup_lexicon` advancement, so players can start progressing without having to find the indicators.

## Before

<img width="612" height="182" alt="image" src="https://github.com/user-attachments/assets/ee27ebb2-dd34-4237-85bd-33a4583e142a" />

<img width="834" height="561" alt="image" src="https://github.com/user-attachments/assets/a2059afc-a521-44d7-a4d0-befaaa1838fe" />

## After

<img width="889" height="198" alt="image" src="https://github.com/user-attachments/assets/64e28f47-b471-4394-a0e1-a5c455c1aeaf" />

<img width="484" height="209" alt="image" src="https://github.com/user-attachments/assets/ff7d260a-bab5-4d1f-93f3-93c132a761cf" />

<img width="811" height="546" alt="image" src="https://github.com/user-attachments/assets/533cb4c8-7734-42ea-b3a7-45201245eacd" />
