### PR TITLE
Allow iron/copper plates from other mods in Immersive Aircraft recipes

### DIFF
--- a/overrides/kubejs/server_scripts/Common/Recipes/immersive_aircraft.js
+++ b/overrides/kubejs/server_scripts/Common/Recipes/immersive_aircraft.js
@@ -1,0 +1,15 @@
+ServerEvents.recipes(event => {
+
+    event.replaceInput(
+        { mod: 'immersive_aircraft' },
+        'create:iron_sheet',
+        '#forge:plates/iron'
+    )
+
+    event.replaceInput(
+        { mod: 'immersive_aircraft' },
+        'create:copper_sheet',
+        '#forge:plates/copper'
+    )
+
+})


### PR DESCRIPTION
Consistent with other create-based recipes