### PR TITLE
Disable mailbox chapter completion sound

### DIFF
--- a/overrides/config/ftbquests/quests/chapters/mailbox.snbt
+++ b/overrides/config/ftbquests/quests/chapters/mailbox.snbt
@@ -1,6 +1,7 @@
 {
 	default_hide_dependency_lines: false
 	default_quest_shape: ""
+	disable_toast: true
 	filename: "mailbox"
 	group: "12BCDDCCCA65FD77"
 	icon: "mighty_mail:mangrove_mail_box"
@@ -764,3 +765,4 @@
 	]
 	title: "&7The Mailbox"
 }
+


### PR DESCRIPTION
Every time someone claimed the items from the Gruncle Vlad's letter (or just wanted to annoy people), the entire team would hear the loud chapter complete sound.