### PR TITLE
Cap wither healing per hit

### DIFF
--- a/overrides/kubejs/startup_scripts/wither_antiheal.js
+++ b/overrides/kubejs/startup_scripts/wither_antiheal.js
@@ -1,0 +1,11 @@
+const MAX_HEAL = 5
+
+const $LivingHealEvent = Java.loadClass(
+    "net.minecraftforge.event.entity.living.LivingHealEvent"
+)
+
+ForgeEvents.onEvent($LivingHealEvent, (event) => {
+	if (event.entity.getType().toString() === 'minecraft:wither') {
+		event.amount = Math.min(event.amount, MAX_HEAL)
+	}
+})


### PR DESCRIPTION
The wither boss from Wither Reincarnated is supposed to heal when it or a mob it has possessed attacks another mob. However, the healing is based on **raw attack damage**, not damage actually dealt. This means when the wither hits a random animal with its 300 damage laser attack, it heals 300 health instead of absorbing the animal's max health. Healing to full after hitting 2 or 3 random mobs with the laser is not exactly fair or fun.

This PR caps wither healing to a certain value per heal. It is 5 health for now, but you can change it to whatever number you want after some testing.