### PR TITLE
Add mysterious orb instructions to tooltip

### DIFF
--- a/overrides/kubejs/assets/kubejs/lang/en_us.json
+++ b/overrides/kubejs/assets/kubejs/lang/en_us.json
@@ -190,6 +190,7 @@
     "tooltip.mce2.savageandravage.blast_proof_plates": "§oImmune to Explosions and Dragons",
     "tooltip.mce2.immersiveengineering.blastbrick_reinforced": "§oImmune to Dragons",
     "tooltip.mce2.pneumaticcraft.reinforced_stone": "§oImmune to Dragons",
+    "tooltip.mce2.alshanex_familiars.mysterious_orb": "§fRight Click a block to reveal the artifacts within",
     "tooltip.mce2.naturescompass.naturescompass": "§e▸Traded by Goblin Trader",
     "tooltip.mce2.kubejs.loyalty_card_bm.1": "§7§oCan be exchanged for a reward by a Goblin Trader!",
     "tooltip.mce2.kubejs.loyalty_card_curio.1": "§7§oCan be exchanged for a reward by a Goblin Trader!",

--- a/overrides/kubejs/client_scripts/tooltips.js
+++ b/overrides/kubejs/client_scripts/tooltips.js
@@ -121,6 +121,7 @@ ItemEvents.tooltip(event => {
 	event.add('savageandravage:blast_proof_plates', Text.translate("tooltip.mce2.savageandravage.blast_proof_plates").color('#4F0D75'));
 	event.add('immersiveengineering:blastbrick_reinforced', Text.translate("tooltip.mce2.immersiveengineering.blastbrick_reinforced").color('#4F0D75'));
 	event.add('pneumaticcraft:reinforced_stone', Text.translate("tooltip.mce2.pneumaticcraft.reinforced_stone").color('#4F0D75'));
+	event.add('alshanex_familiars:mysterious_orb',  Text.translate('tooltip.mce2.alshanex_familiars.mysterious_orb').color('#FFFFFF'));
 	event.add('naturescompass:naturescompass', Text.translate("tooltip.mce2.naturescompass.naturescompass").color('#FFAA00'));
 	event.add('kubejs:loyalty_card_bm', Text.translate("tooltip.mce2.kubejs.loyalty_card_bm.1").color('#FFFFFF'));
 	event.add('kubejs:loyalty_card_curio', Text.translate("tooltip.mce2.kubejs.loyalty_card_curio.1").color('#FFFFFF'));


### PR DESCRIPTION
Some players were confused what the Mysterious Orb from Alshanex's Familiars did, since it does not open on any right click (has to be clicking a block) unlike other items.