### PR TITLE
Add modded beehives to bumblezone teleport blocks

### DIFF
--- a/overrides/kubejs/data/the_bumblezone/tags/blocks/dimension_teleportation/forced_allowed_teleportable_blocks.json
+++ b/overrides/kubejs/data/the_bumblezone/tags/blocks/dimension_teleportation/forced_allowed_teleportable_blocks.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "#minecraft:beehives",
+    "complicated_bees:apiary",
+    "complicated_bees:bee_nest",
+    "minecolonies:blockhutbeekeeper"
+  ]
+}


### PR DESCRIPTION
Does not include the mellarium multiblock since there is no way to detect whether the multiblock is valid through tags alone.