### PR TITLE
fix(config): remove invalid item ID from ArmorDamageLimit blacklist

### DIFF
--- a/overrides/config/ArmorDamageLimit.toml
+++ b/overrides/config/ArmorDamageLimit.toml
@@ -1,7 +1,5 @@
-
 [Config]
 	#Range: 0.01 ~ 1.0
 	"Max Armor Durability Loss Percentage" = 0.02
 	#Armor items that will not be protected
-	"Item Protection Blacklist" = ["modA:armorB"]
-
+	"Item Protection Blacklist" = []

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "app",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
1. Summary of changes: Removed the invalid placeholder entry 'modA:armorB' from the 'Item Protection Blacklist' in `overrides/config/ArmorDamageLimit.toml`.
2. Rationale behind the implementation: The entry 'modA:armorB' appears to be a default placeholder artifact and does not correspond to any item within the modpack's active configuration. Its presence is misleading and unnecessary for correct mod functionality.
3. Technical impact analysis: The change improves configuration clarity and removes dead identifiers, ensuring that only intended items, if any, are protected from durability loss. This fix has no negative impact on system performance or mod functionality.