### PR TITLE
Request to Update majruszsaccessories.json

### DIFF
--- a/overrides/config/majruszsaccessories.json
+++ b/overrides/config/majruszsaccessories.json
@@ -54,7 +54,7 @@
     },
     "angler_rune": {
       "fishing_luck": {
-        "bonus": 2.0,
+        "bonus": 2.5,
         "bonus_range": {
           "min": 0.0,
           "max": 10.0
@@ -77,7 +77,7 @@
     },
     "angler_trophy": {
       "fishing_luck": {
-        "bonus": 2.5,
+        "bonus": 2.0,
         "bonus_range": {
           "min": 0.0,
           "max": 10.0
@@ -87,7 +87,7 @@
     },
     "certificate_of_taming": {
       "animal_bonus": {
-        "bonus": 0.5,
+        "bonus": 0.3,
         "bonus_range": {
           "min": 0.0,
           "max": 1.0
@@ -233,7 +233,7 @@
     },
     "lucky_rock": {
       "extra_mining_item": {
-        "chance": 0.001,
+        "chance": 0.02,
         "chance_range": {
           "min": 0.0,
           "max": 0.4
@@ -334,7 +334,7 @@
     },
     "nature_rune": {
       "animal_bonus": {
-        "bonus": 0.25,
+        "bonus": 0.4,
         "bonus_range": {
           "min": 0.0,
           "max": 1.0
@@ -505,7 +505,7 @@
         }
       },
       "animal_bonus": {
-        "bonus": 0.3,
+        "bonus": 0.5,
         "bonus_range": {
           "min": 0.0,
           "max": 1.0

--- a/overrides/config/majruszsaccessories.json
+++ b/overrides/config/majruszsaccessories.json
@@ -233,7 +233,7 @@
     },
     "lucky_rock": {
       "extra_mining_item": {
-        "chance": 0.02,
+        "chance": 0.075,
         "chance_range": {
           "min": 0.0,
           "max": 0.4
@@ -306,7 +306,7 @@
     },
     "miner_rune": {
       "extra_mining_item": {
-        "chance": 0.04,
+        "chance": 0.03,
         "chance_range": {
           "min": 0.0,
           "max": 1.0


### PR DESCRIPTION
Fixing swapped values between Accessories and their Runes, to ensure power scaling is always positive instead of the previous mismatch up and down. Also, buffed Lucky Rock to be useful and in line with its constituents.

Below are the exact values changed and an explanation:

- **Lucky Rock** went from being 1/40 that of its rune (was literally 0.16% chance at max), to now -> 1/2 as effective (now 3.2%, the rune is still 6.4%, and Soul stayed untouched at 8%).

- **Certificate of Taming** is 80% at max currently, meanwhile its upgrades are at 40 and 56, respectively. I have now changed them to -> 48, 64, and 80, respectively. 
If these feel too high, please change the respective "animal_bonus" values from ".3, .4, .5" to ".25, .3, .5," and it will match the old pattern/values of 40, 56, 80 (except in the correct order).

- **Angler's Trophy** is currently +4 luck at max, and the rune is 3.2. I have swapped these two. Soul is untouched.