### PR TITLE
Add Iris & Oculus Search Mod to search shader settings and shader packs within the GUI

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1961,6 +1961,12 @@
       "isLocked": false
     },
     {
+      "projectID": 1583035,
+      "fileID": 8480803,
+      "required": true,
+      "isLocked": false
+    },
+    {
       "projectID": 679166,
       "fileID": 4013521,
       "required": true,


### PR DESCRIPTION
I suggest adding the IrisSearch mod:

If you’re tired of clicking through endless pages and sub-menus just to find a specific toggle like waving foliage or bloom, this mod is for you! It embeds a functional search bar right into the shader options GUI. Just type what you need, and the menu dynamically filters down to the matching settings instantly.

This is a purely client-side mod, supports translation/localized shader options, and requires zero setup out of the box.

**Works with Iris, Oculus and other derivatives on Fabric, Forge, and NeoForge (1.20.1+)!**

- Link to mod : **Download on [Modrinth](<https://modrinth.com/mod/irissearch>) or [CurseForge](<https://www.curseforge.com/minecraft/mc-mods/irissearch>)**

## Features
- **Search Shader Settings** or **Search Shader Packs** seamlessly in the GUI
- **In-GUI Search Bar:** Adds a seamlessly integrated text input field directly inside the shader pack options menu and the shaderpack selection screen
- **Translation Support:** Search in your selected language (if supported by the shader). The mod itself is also translatable. Contribute [here on GitHub](https://github.com/SpacEagle17/IrisSearch/tree/main/common/src/main/resources/assets/iris_search/lang).
- **No Setup Needed:** Works completely out of the box with zero configuration files to edit.
- **Loader Compatibility:** Available for Fabric, Forge, and NeoForge.
- **Version Support:** Compatible from 1.20.1 up to the latest Minecraft versions.

https://github.com/user-attachments/assets/3dc1e946-ceae-4055-b6a5-b7fafabced6f

<img width="2560" height="1417" alt="image" src="https://github.com/user-attachments/assets/4c4f5442-1d95-4cd4-a823-dccd23be65b8" />

<img width="1206" height="435" alt="2026-07-03_17 27 51_ApplicationFrameHost_1206x435_SpacEagle17" src="https://github.com/user-attachments/assets/30ce50c7-b950-4b19-a3db-4577bb37ca2b" />